### PR TITLE
Set default root controller namespace for each module

### DIFF
--- a/src/Caffeinated/Modules/Console/ModuleMigrateCommand.php
+++ b/src/Caffeinated/Modules/Console/ModuleMigrateCommand.php
@@ -3,13 +3,17 @@ namespace Caffeinated\Modules\Console;
 
 use Caffeinated\Modules\Modules;
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
+
 class ModuleMigrateCommand extends Command
 {
+    use ConfirmableTrait;
+
 	/**
 	 * @var string $name The console command name.
 	 */
@@ -51,6 +55,8 @@ class ModuleMigrateCommand extends Command
 	 */
 	public function fire()
 	{
+        if ( ! $this->confirmToProceed()) return null;
+
 		$this->prepareDatabase();
 
 		$module = $this->argument('module');

--- a/src/Caffeinated/Modules/Console/ModuleMigrateRefreshCommand.php
+++ b/src/Caffeinated/Modules/Console/ModuleMigrateRefreshCommand.php
@@ -2,12 +2,15 @@
 namespace Caffeinated\Modules\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 class ModuleMigrateRefreshCommand extends Command
 {
+    use ConfirmableTrait;
+
 	/**
 	 * @var string $name The console command name.
 	 */
@@ -33,7 +36,9 @@ class ModuleMigrateRefreshCommand extends Command
 	 */
 	public function fire()
 	{
-		$module     = $this->argument('module');
+        if ( ! $this->confirmToProceed()) return null;
+
+        $module     = $this->argument('module');
 		$moduleName = Str::studly($module);
 
 		$this->call('module:migrate-reset', [

--- a/src/Caffeinated/Modules/Console/ModuleMigrateResetCommand.php
+++ b/src/Caffeinated/Modules/Console/ModuleMigrateResetCommand.php
@@ -2,6 +2,7 @@
 namespace Caffeinated\Modules\Console;
 
 use Caffeinated\Modules\Modules;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Console\Command;
@@ -10,6 +11,8 @@ use Symfony\Component\Console\Input\InputArgument;
 
 class ModuleMigrateResetCommand extends Command
 {
+    use ConfirmableTrait;
+
 	/**
 	 * @var string $name The console command name.
 	 */
@@ -58,6 +61,8 @@ class ModuleMigrateResetCommand extends Command
 	 */
 	public function fire()
 	{
+        if ( ! $this->confirmToProceed()) return null;
+
 		$module = $this->argument('module');
 
 		if ($module) {
@@ -183,7 +188,8 @@ class ModuleMigrateResetCommand extends Command
 	{
 		return [
 			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
-			['pretend', null, InputOption::VALUE_OPTIONAL, 'Dump the SQL queries that would be run.'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run while in production.'],
+            ['pretend', null, InputOption::VALUE_OPTIONAL, 'Dump the SQL queries that would be run.'],
 			['seed', null, InputOption::VALUE_OPTIONAL, 'Indicates if the seed task should be re-run.']
 		];
 	}

--- a/src/Caffeinated/Modules/Console/ModuleMigrateRollbackCommand.php
+++ b/src/Caffeinated/Modules/Console/ModuleMigrateRollbackCommand.php
@@ -3,6 +3,7 @@ namespace Caffeinated\Modules\Console;
 
 use Caffeinated\Modules\Modules;
 use Caffeinated\Modules\Traits\MigrationTrait;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Input\InputArgument;
 class ModuleMigrateRollbackCommand extends Command
 {
 	use MigrationTrait;
+    use ConfirmableTrait;
 
 	/**
 	 * @var string $name The console command name.
@@ -46,6 +48,8 @@ class ModuleMigrateRollbackCommand extends Command
 	 */
 	public function fire()
 	{
+        if ( ! $this->confirmToProceed()) return null;
+
 		$module = $this->argument('module');
 
 		if ($module) {

--- a/src/Caffeinated/Modules/Console/ModuleSeedCommand.php
+++ b/src/Caffeinated/Modules/Console/ModuleSeedCommand.php
@@ -85,6 +85,10 @@ class ModuleSeedCommand extends Command
 			$params['--database'] = $option;
 		}
 
+        if ($option = $this->option('force')) {
+            $params['--force'] = $option;
+        }
+
 		$this->call('db:seed', $params);
 	}
 
@@ -107,7 +111,8 @@ class ModuleSeedCommand extends Command
 	{
 		return [
 			['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the module\'s root seeder.'],
-			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed.']
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed.'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run while in production.'],
 		];
 	}
 }

--- a/src/Caffeinated/Modules/Console/stubs/routeserviceprovider.stub
+++ b/src/Caffeinated/Modules/Console/stubs/routeserviceprovider.stub
@@ -36,7 +36,7 @@ class RouteServiceProvider extends ServiceProvider
 	 */
 	public function map(Router $router)
 	{
-		$router->group(['namespace' => $this->namespace], function($router)
+		$router->group(['namespace' => $this->namespace, 'middleware'=>'caffeinated.module'], function($router)
 		{
 			require (config('modules.path').'/{{name}}/Http/routes.php');
 		});

--- a/src/Caffeinated/Modules/Middleware/ModuleMiddleware.php
+++ b/src/Caffeinated/Modules/Middleware/ModuleMiddleware.php
@@ -1,0 +1,51 @@
+<?php
+namespace Caffeinated\Modules\Middleware;
+
+
+use Closure;
+use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Support\Str;
+
+
+class ModuleMiddleware {
+
+    /**
+     * The UrlGenerator implementation.
+     *
+     * @var UrlGenerator
+     */
+    protected $urlGenerator;
+
+    /**
+     * Create a new filter instance.
+     *
+     * @param  UrlGenerator  $urlGenerator
+     */
+    public function __construct(UrlGenerator $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    /**
+     * Handle an incoming request and set root controller namespace in a module
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+
+        $route=$request->route();
+        if (!is_null($route)) {
+            $action =$route->getAction();
+            if (!empty($action['namespace'])) {
+                if (Str::startsWith($action['namespace'], app('modules')->getNamespace())) {
+                    $this->urlGenerator->setRootControllerNamespace($action['namespace']);
+                }
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Caffeinated/Modules/ModulesServiceProvider.php
+++ b/src/Caffeinated/Modules/ModulesServiceProvider.php
@@ -38,6 +38,8 @@ class ModulesServiceProvider extends ServiceProvider
 
 		$this->registerServices();
 
+        $this->registerMiddleware();
+
 		$this->registerRepository();
 
 		// Once we have registered the migrator instance we will go ahead and register
@@ -278,4 +280,12 @@ class ModulesServiceProvider extends ServiceProvider
 			return new Console\ModuleListCommand($app['modules']);
 		});
 	}
+
+    /**
+     * Register the ModuleMiddleware
+     */
+    protected function registerMiddleware()
+    {
+        $this->app['router']->middleware('caffeinated.module','Caffeinated\Modules\Middleware\ModuleMiddleware');
+    }
 }


### PR DESCRIPTION
A nice enhacement could be to automatically set the default controler namespace for each module.
Then you can call directly Module controller without specify the full namespace


````
namespace Test\Modules\Blog\Http\Controllers;

class BlogController extends \Test\Http\Controllers\Controller 
{
    public function index() {
        // You can call directly Module controller without specify the
        // full namespace \Test\Modules\Blog\Http\Controllers\BlogController@index
        return \URL::action('BlogController@index');
    }
}

````