### PR TITLE
Feature/root controller

### DIFF
--- a/src/Caffeinated/Modules/Console/stubs/routeserviceprovider.stub
+++ b/src/Caffeinated/Modules/Console/stubs/routeserviceprovider.stub
@@ -36,7 +36,7 @@ class RouteServiceProvider extends ServiceProvider
 	 */
 	public function map(Router $router)
 	{
-		$router->group(['namespace' => $this->namespace], function($router)
+		$router->group(['namespace' => $this->namespace, 'middleware'=>'caffeinated.module'], function($router)
 		{
 			require (config('modules.path').'/{{name}}/Http/routes.php');
 		});

--- a/src/Caffeinated/Modules/Middleware/ModuleMiddleware.php
+++ b/src/Caffeinated/Modules/Middleware/ModuleMiddleware.php
@@ -1,0 +1,51 @@
+<?php
+namespace Caffeinated\Modules\Middleware;
+
+
+use Closure;
+use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Support\Str;
+
+
+class ModuleMiddleware {
+
+    /**
+     * The UrlGenerator implementation.
+     *
+     * @var UrlGenerator
+     */
+    protected $urlGenerator;
+
+    /**
+     * Create a new filter instance.
+     *
+     * @param  UrlGenerator  $urlGenerator
+     */
+    public function __construct(UrlGenerator $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    /**
+     * Handle an incoming request and set root controller namespace in a module
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+
+        $route=$request->route();
+        if (!is_null($route)) {
+            $action =$route->getAction();
+            if (!empty($action['namespace'])) {
+                if (Str::startsWith($action['namespace'], app('modules')->getNamespace())) {
+                    $this->urlGenerator->setRootControllerNamespace($action['namespace']);
+                }
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Caffeinated/Modules/Middleware/ModuleMiddleware.php
+++ b/src/Caffeinated/Modules/Middleware/ModuleMiddleware.php
@@ -1,14 +1,12 @@
 <?php
 namespace Caffeinated\Modules\Middleware;
 
-
 use Closure;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Support\Str;
 
-
-class ModuleMiddleware {
-
+class ModuleMiddleware
+{
     /**
      * The UrlGenerator implementation.
      *
@@ -19,7 +17,7 @@ class ModuleMiddleware {
     /**
      * Create a new filter instance.
      *
-     * @param  UrlGenerator  $urlGenerator
+     * @param UrlGenerator $urlGenerator
      */
     public function __construct(UrlGenerator $urlGenerator)
     {
@@ -27,18 +25,18 @@ class ModuleMiddleware {
     }
 
     /**
-     * Handle an incoming request and set root controller namespace in a module
+     * Handle an incoming request and set root controller namespace in a module.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
      * @return mixed
      */
     public function handle($request, Closure $next)
     {
-
-        $route=$request->route();
+        $route = $request->route();
         if (!is_null($route)) {
-            $action =$route->getAction();
+            $action = $route->getAction();
             if (!empty($action['namespace'])) {
                 if (Str::startsWith($action['namespace'], app('modules')->getNamespace())) {
                     $this->urlGenerator->setRootControllerNamespace($action['namespace']);

--- a/src/Caffeinated/Modules/ModulesServiceProvider.php
+++ b/src/Caffeinated/Modules/ModulesServiceProvider.php
@@ -38,6 +38,8 @@ class ModulesServiceProvider extends ServiceProvider
 
 		$this->registerServices();
 
+        $this->registerMiddleware();
+
 		$this->registerRepository();
 
 		// Once we have registered the migrator instance we will go ahead and register
@@ -278,4 +280,12 @@ class ModulesServiceProvider extends ServiceProvider
 			return new Console\ModuleListCommand($app['modules']);
 		});
 	}
+
+    /**
+     * Register the ModuleMiddleware
+     */
+    protected function registerMiddleware()
+    {
+        $this->app['router']->middleware('caffeinated.module','Caffeinated\Modules\Middleware\ModuleMiddleware');
+    }
 }


### PR DESCRIPTION
A nice enhacement could be to automatically set the default controler namespace for each module.
Then you can call directly Module controller without specify the full namespace


````
namespace Test\Modules\Blog\Http\Controllers;

class BlogController extends \Test\Http\Controllers\Controller 
{
    public function index() {
        // You can call directly Module controller without specify the
        // full namespace \Test\Modules\Blog\Http\Controllers\BlogController@index
        return \URL::action('BlogController@index');
    }
}

````