### PR TITLE
Enable and disable modules per request

### DIFF
--- a/src/Caffeinated/Modules/Console/ModuleDisableCommand.php
+++ b/src/Caffeinated/Modules/Console/ModuleDisableCommand.php
@@ -34,7 +34,7 @@ class ModuleDisableCommand extends Command
 		$module = $this->argument('module');
 
 		if ($this->laravel['modules']->isEnabled($this->argument('module'))) {
-			$this->laravel['modules']->disable($module);
+			$this->laravel['modules']->setDisabled($module);
 
 			$this->info("Module [{$module}] was disabled successfully.");
 		} else {

--- a/src/Caffeinated/Modules/Console/ModuleEnableCommand.php
+++ b/src/Caffeinated/Modules/Console/ModuleEnableCommand.php
@@ -34,7 +34,7 @@ class ModuleEnableCommand extends Command
 		$module = $this->argument('module');
 
 		if ($this->laravel['modules']->isDisabled($this->argument('module'))) {
-			$this->laravel['modules']->enable($module);
+			$this->laravel['modules']->setEnabled($module);
 
 			$this->info("Module [{$module}] was enabled successfully.");
 		} else {

--- a/src/Caffeinated/Modules/Modules.php
+++ b/src/Caffeinated/Modules/Modules.php
@@ -26,7 +26,12 @@ class Modules implements Countable
 	 */
 	protected $path;
 
-	/**
+    /**
+     * @var array $runtimeEnabled Run-time enabled modules
+     */
+    protected $runtimeEnabled;
+
+    /**
 	 * Constructor method.
 	 *
 	 * @param \Illuminate\Config\Repository                $config
@@ -36,7 +41,9 @@ class Modules implements Countable
 	{
 		$this->config = $config;
 		$this->files  = $files;
-	}
+        $this->runtimeEnabled = [];
+
+    }
 
 	/**
 	 * Register the module service provider file from all modules.
@@ -55,7 +62,7 @@ class Modules implements Countable
 	 *
 	 * @param  string $module
 	 * @return string
-	 * @throws \Caffeinated\Modules\Exception\FileMissingException
+	 * @throws \Caffeinated\Modules\Exceptions\FileMissingException
 	 */
 	protected function registerServiceProvider($module)
 	{
@@ -202,7 +209,8 @@ class Modules implements Countable
 	 * Get path for the specified module.
 	 *
 	 * @param  string $slug
-	 * @return string
+     * @param  bool   $allowNotExists
+     * @return string
 	 */
 	public function getModulePath($slug, $allowNotExists = false)
 	{
@@ -325,7 +333,20 @@ class Modules implements Countable
 		return $this->getByEnabled(false);
 	}
 
-	/**
+    /**
+     * Check if specified module is enabled at runtime.
+     * @param $slug
+     * @return bool
+     */
+    protected function isRuntimeEnabled($slug)
+    {
+        if (isset($this->runtimeEnabled[$slug])) {
+            return $this->runtimeEnabled[$slug] === true;
+        }
+        return false;
+    }
+
+    /**
 	 * Check if specified module is enabled.
 	 *
 	 * @param  string $slug
@@ -333,8 +354,8 @@ class Modules implements Countable
 	 */
 	public function isEnabled($slug)
 	{
-		return $this->getProperty("{$slug}::enabled") === true;
-	}
+        return $this->isRuntimeEnabled($slug) || $this->getProperty("{$slug}::enabled") === true;
+    }
 
 	/**
 	 * Check if specified module is disabled.
@@ -344,8 +365,8 @@ class Modules implements Countable
 	 */
 	public function isDisabled($slug)
 	{
-		return $this->getProperty("{$slug}::enabled") === false;
-	}
+        return !$this->isRuntimeEnabled($slug) || $this->getProperty("{$slug}::enabled") === false;
+    }
 
 	/**
 	 * Enables the specified module.
@@ -355,8 +376,12 @@ class Modules implements Countable
 	 */
 	public function enable($slug)
 	{
-		return $this->setProperty("{$slug}::enabled", true);
-	}
+        if ($this->exists($slug)) {
+            $this->runtimeEnabled[$slug] = true;
+            return true;
+        }
+        return false;
+    }
 
 	/**
 	 * Disables the specified module.
@@ -366,15 +391,44 @@ class Modules implements Countable
 	 */
 	public function disable($slug)
 	{
-		return $this->setProperty("{$slug}::enabled", false);
+        if ($this->exists($slug)) {
+            $this->runtimeEnabled[$slug] = false;
+            return true;
+        }
+        return false;
 	}
 
-	/**
-	 * Get module JSON content as an array.
-	 *
-	 * @param  string $module
-	 * @return array|mixed
-	 */
+    /**
+     * Saves enabled state in the specified module.
+     *
+     * @param  string $slug
+     * @return bool
+     */
+    public function setEnabled($slug)
+    {
+        return $this->setProperty("{$slug}::enabled", true);
+    }
+
+    /**
+     * Saves disbled state in the specified module.
+     *
+     * @param  string $slug
+     * @return bool
+     */
+    public function setDisabled($slug)
+    {
+        return $this->setProperty("{$slug}::enabled", false);
+    }
+
+
+    /**
+     * Get module JSON content as an array.
+     *
+     * @param  string $module
+     * @return array|mixed
+     * @throws FileMissingException
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
 	protected function getJsonContents($module)
 	{
 		$module = Str::studly($module);


### PR DESCRIPTION
Analyzing the problems described in issue #15 and issue #46 , I propose a little change of behavior.

When module is enabled or disabled using Module Facade, instead of writing module.json file, I prefere maintain a registry of enabled and disabled modules, and keep the actual functionality only for the Command

In this way we can enable and disable modules dynamically without deal with file system permissions.

The modules must be enabled or disabled before *ModuleServiceProvider* boot.

**/app/Providers/AppServiceProvider.php**

````
<?php namespace App\Providers;

use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider {

    /**
     * Bootstrap any application services.
     *
     * @return void
     */
    public function boot()
    {
        //
    }

    /**
     * Register any application services.
     *
     * This service provider is a great spot to register your various container
     * bindings with the application. As you can see, we are registering our
     * "Registrar" implementation here. You can add your own bindings too!
     *
     * @return void
     */
    public function register()
    {
        $this->app->bind(
            'Illuminate\Contracts\Auth\Registrar',
            'App\Services\Registrar'
        );

        $this->app->booting( function ($app) {
           $app['modules']->enable('blog');
           \Modules::disable('pages')
        } );
    }
}
````