### PR TITLE
Fix bug in module make migration command, not replacing place-holder with table name.

### DIFF
--- a/resources/stubs/migration.stub
+++ b/resources/stubs/migration.stub
@@ -12,7 +12,7 @@ class {{className}} extends Migration
 	 */
 	public function up()
 	{
-		Schema::create('table_name', function (Blueprint $table) {
+		Schema::create('{{table_name}}', function (Blueprint $table) {
 			$table->increments('id');
 		});
 	}
@@ -24,6 +24,6 @@ class {{className}} extends Migration
 	 */
 	public function down()
 	{
-		Schema::dropIfExists('table_name');
+		Schema::dropIfExists('{{table_name}}');
 	}
 }

--- a/src/Console/Generators/MakeMigrationCommand.php
+++ b/src/Console/Generators/MakeMigrationCommand.php
@@ -129,7 +129,7 @@ class MakeMigrationCommand extends Command
 	protected function formatContent($content)
     {
         return str_replace(
-			['{{className}}', '{{table}}'],
+			['{{className}}', '{{table_name}}'],
 			[$this->container['className'], $this->container['table']],
 			$content
 		);


### PR DESCRIPTION
When invoking the command `make:module:migration` the table name is not replaced in the migration stub.
This patch fixes that issue.