### PR TITLE
Call a one off method when a module is enabled or disabled

### DIFF
--- a/resources/stubs/maintenance.stub
+++ b/resources/stubs/maintenance.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{path}}\{{namespace}}\Utils;
+
+class {{namespace}}Maintenance
+{
+
+    static public function enable()
+    {
+        //
+    }
+
+    static public function disable()
+    {
+        //
+    }
+
+}

--- a/src/Console/Generators/MakeModuleCommand.php
+++ b/src/Console/Generators/MakeModuleCommand.php
@@ -44,6 +44,7 @@ class MakeModuleCommand extends Command
         'Resources/',
         'Resources/Lang/',
         'Resources/Views/',
+        'Utils/',
     ];
 
     /**
@@ -56,6 +57,7 @@ class MakeModuleCommand extends Command
         'Http/routes.php',
         'Providers/{{namespace}}ServiceProvider.php',
         'Providers/RouteServiceProvider.php',
+        'Utils/{{namespace}}Maintenance.php',
         'module.json',
     ];
 
@@ -69,6 +71,7 @@ class MakeModuleCommand extends Command
         'routes.stub',
         'moduleserviceprovider.stub',
         'routeserviceprovider.stub',
+        'maintenance.stub',
         'manifest.stub',
     ];
 

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -301,6 +301,11 @@ class Modules implements RepositoryInterface
      */
     public function enable($slug)
     {
+        // Resolve and invoke the modules own initialize method.
+        // Thanks to sroutier/l51esk-modules
+        $maintenanceInstance = $this->getMaintenance($slug);
+        $maintenanceInstance::enable();
+
         return $this->repository->enable($slug);
     }
 
@@ -313,6 +318,11 @@ class Modules implements RepositoryInterface
      */
     public function disable($slug)
     {
+        // Resolve and invoke the modules own initialize method.
+        // Thanks to sroutier/l51esk-modules
+        $maintenanceInstance = $this->getMaintenance($slug);
+        $maintenanceInstance::disable();
+
         return $this->repository->disable($slug);
     }
 
@@ -327,5 +337,23 @@ class Modules implements RepositoryInterface
             ? $properties['namespace']
             : studly_case($properties['slug'])
         ;
+    }
+
+    /**
+     * Resolve and instantiate the module's maintenance class.
+     * Thanks to sroutier/l51esk-modules
+     *
+     * @param $slug
+     * @return object
+     */
+    public function getMaintenance($slug)
+    {
+        $maintenanceInstance = null;
+        $nameSpace = \Module::where('slug', $slug)->first()['namespace'];
+        $maintenanceFile  =        config('modules.path')      . '/' . $nameSpace . '/Utils/'   . $nameSpace . 'Maintenance.php';
+        $maintenanceClass = '\\' . config('modules.namespace') .       $nameSpace . '\\Utils\\' . $nameSpace . 'Maintenance';
+        require($maintenanceFile);
+        $maintenanceInstance = new $maintenanceClass();
+        return $maintenanceInstance;
     }
 }


### PR DESCRIPTION
As I mentioned in this issue/request #182, I really needed this functionality within the application, so thank you to @sroutier I have implemented this functionality using the changes he made within his own [fork here](https://github.com/sroutier/l51esk-modules). I hope you don't mind :).

The following changes have been made:
- When creating a module a new Utils/{Module}Maintenance.php class is created. This has two static methods, enable and disable.
- When a module is enabled, the static enable method on the maintenance class for that module is called.
- When a module is disabled, the static disable method on the maintenance class for that module is called.