### PR TITLE
Added a ModulePath folder check to be sure the directory exists ...

### DIFF
--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -67,8 +67,7 @@ abstract class Repository implements RepositoryContract
     public function getManifest($slug)
     {
         if (! is_null($slug)) {
-            $module     = str_slug($slug);
-            $path       = $this->getManifestPath($module);
+            $path       = $this->getManifestPath($slug);
             $contents   = $this->files->get($path);
             $collection = collect(json_decode($contents, true));
 
@@ -111,15 +110,19 @@ abstract class Repository implements RepositoryContract
      */
     public function getModulePath($slug)
     {
-        $module = studly_case($slug);
+        $module = studly_case(str_slug($slug));
 
-        return $this->getPath()."/{$module}/";
+        if(\File::exists($this->getPath()."/{$module}/")) {
+            return $this->getPath()."/{$module}/";
+        }
+
+        return $this->getPath()."/{$slug}/";
     }
 
     /**
      * Get path of module manifest file.
      *
-     * @param string $module
+     * @param $slug
      *
      * @return string
      */


### PR DESCRIPTION
I have some old left-over directories who used the `FooBar`, `BarBiz` folder structure and in the current situation, this will become `str_slug` -> `studly_case`, so `Foobar`, `Barbiz`.

I added a check if the current folder-directory exists, otherwise use the `FooBar` folder structure ...