### PR TITLE
Resolve custom path and custom namespace

### DIFF
--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -41,7 +41,6 @@ abstract class GeneratorCommand extends LaravelGeneratorCommand
     protected function getPath($name)
     {
         $rootNamespace = config('modules.namespace');
-        $name = str_replace($this->laravel->getNamespace(), '', $name);
         $name = str_replace($rootNamespace, '', $name);
 
         return module_path().'/'.str_replace('\\', '/', $name).'.php';

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -31,4 +31,19 @@ abstract class GeneratorCommand extends LaravelGeneratorCommand
 
         return $this->parseName($this->getDefaultNamespace(trim($rootNamespace, '\\')).'\\'.$name);
     }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $rootNamespace = config('modules.namespace');
+        $name = str_replace($this->laravel->getNamespace(), '', $name);
+        $name = str_replace($rootNamespace, '', $name);
+
+        return module_path().'/'.str_replace('\\', '/', $name).'.php';
+    }
 }


### PR DESCRIPTION
Custom Namespace dan Path

**config modules.php**
```
'path' => base_path('modules'),
'namespace' => 'MyCustom\\Vendor\\Modules\\',
```

If it generates a controller module, should be towards the folder
`modules/ModuleName/Http/Controllers/<ControllerName>.php`

NOT
`app/MyCustom/Vendor/Modules/ModuleName/Http/Controllers/<ControllerName>.php`