### PR TITLE
Change session()->put to session()->flash in middleware

### DIFF
--- a/src/Middleware/IdentifyModule.php
+++ b/src/Middleware/IdentifyModule.php
@@ -32,7 +32,7 @@ class IdentifyModule
      */
     public function handle($request, Closure $next, $slug = null)
     {
-        $request->session()->put('module', $this->module->where('slug', $slug));
+        $request->session()->flash('module', $this->module->where('slug', $slug));
 
         return $next($request);
     }


### PR DESCRIPTION
Using session()->flash in the middleware makes the module live only as long as the duration of the request, whereas session()-put lives for the duration of the session. This fixed an issue when running some pages inside modules and others outside - pages outside of a module believe they are in the previously visited module due to the session variable existing from previous requests.