### PR TITLE
Generate seeders in right namespace

### DIFF
--- a/src/Console/Commands/ModuleSeedCommand.php
+++ b/src/Console/Commands/ModuleSeedCommand.php
@@ -86,8 +86,8 @@ class ModuleSeedCommand extends Command
         $module        = $this->module->where('slug', $slug);
         $params        = [];
         $namespacePath = $this->module->getNamespace();
-        $rootSeeder    = $module['namespace'].'DatabaseSeeder';
-        $fullPath      = $namespacePath.'\\'.$module['namespace'].'\Database\Seeds\\'.$rootSeeder;
+        $rootSeeder    = $module['name'].'DatabaseSeeder';
+        $fullPath      = $namespacePath.'\\'.$module['name'].'\Database\Seeds\\'.$rootSeeder;
 
         if (class_exists($fullPath)) {
             if ($this->option('class')) {

--- a/src/Console/Generators/MakeSeederCommand.php
+++ b/src/Console/Generators/MakeSeederCommand.php
@@ -60,4 +60,15 @@ class MakeSeederCommand extends GeneratorCommand
     {
         return $name;
     }
+    
+    /**
+     * Replace namespace in seeder stub
+     *
+     * @param string $name
+     * @return string
+     */
+    protected function getNamespace($name)
+    {
+        return module_class($this->argument('slug'), 'Database\Seeds');
+    }
 }

--- a/src/Console/Generators/stubs/seeder.stub
+++ b/src/Console/Generators/stubs/seeder.stub
@@ -1,5 +1,7 @@
 <?php
 
+namespace DummyNamespace;
+
 use Illuminate\Database\Seeder;
 
 class DummyClass extends Seeder


### PR DESCRIPTION
When I'm trying to generate seeder, I've got error:
'Undefindex index namespace'
Seems to be an error from old structure.
Try to fix it.
Now seeders are generating in namespace of slug