### PR TITLE
Allow configuring module subdirectories

### DIFF
--- a/config/modules.php
+++ b/config/modules.php
@@ -55,4 +55,20 @@ return [
     */
 
     'driver' => 'local',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Remap Module Subdirectories
+    |--------------------------------------------------------------------------
+    |
+    | Redefine how module directories are structured. The mapping here will
+    | be respected by all commands and generators.
+    |
+    */
+
+    'pathMap' => [
+        // To change where migrations go, specify the default
+        // location as the key and the new location as the value:
+        // 'Database/Migrations' => 'src/Database/Migrations',
+    ],
 ];

--- a/src/Console/Commands/ModuleMigrateCommand.php
+++ b/src/Console/Commands/ModuleMigrateCommand.php
@@ -136,9 +136,7 @@ class ModuleMigrateCommand extends Command
      */
     protected function getMigrationPath($slug)
     {
-        $path = $this->module->getModulePath($slug);
-
-        return $path.'Database/Migrations/';
+        return module_path($slug, 'Database/Migrations');
     }
 
     /**

--- a/src/Console/Commands/ModuleMigrateResetCommand.php
+++ b/src/Console/Commands/ModuleMigrateResetCommand.php
@@ -185,9 +185,7 @@ class ModuleMigrateResetCommand extends Command
      */
     protected function getMigrationPath($slug)
     {
-        $path = $this->module->getModulePath($slug).'Database/Migrations';
-
-        return $path;
+        return module_path($slug, 'Database/Migrations');
     }
 
     /**

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -40,9 +40,16 @@ abstract class GeneratorCommand extends LaravelGeneratorCommand
      */
     protected function getPath($name)
     {
-        $rootNamespace = config('modules.namespace');
-        $name = str_replace($rootNamespace, '', $name);
+        $slug = $this->argument('slug');
 
-        return module_path().'/'.str_replace('\\', '/', $name).'.php';
+        // take everything after the module name in the given path (ignoring case)
+        $key = array_search(strtolower($slug), explode('\\', strtolower($name)));
+        if ($key === false) {
+            $newPath = str_replace('\\', '/', $name);
+        } else {
+            $newPath = implode('/', array_slice(explode('\\', $name), $key + 1));
+        }
+
+        return module_path($slug, "$newPath.php");
     }
 }

--- a/src/Console/Generators/stubs/controller.resource.stub
+++ b/src/Console/Generators/stubs/controller.resource.stub
@@ -4,8 +4,8 @@ namespace DummyNamespace;
 
 use Illuminate\Http\Request;
 
-use DummyRootNamespaceHttp\Requests;
-use DummyRootNamespaceHttp\Controllers\Controller;
+use DummyRootNamespace\Http\Requests;
+use DummyRootNamespace\Http\Controllers\Controller;
 
 class DummyClass extends Controller
 {

--- a/src/Console/Generators/stubs/controller.stub
+++ b/src/Console/Generators/stubs/controller.stub
@@ -4,8 +4,8 @@ namespace DummyNamespace;
 
 use Illuminate\Http\Request;
 
-use DummyRootNamespaceHttp\Requests;
-use DummyRootNamespaceHttp\Controllers\Controller;
+use DummyRootNamespace\Http\Requests;
+use DummyRootNamespace\Http\Controllers\Controller;
 
 class DummyClass extends Controller
 {

--- a/src/Console/Generators/stubs/request.stub
+++ b/src/Console/Generators/stubs/request.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceHttp\Requests\Request;
+use DummyRootNamespace\Http\Requests\Request;
 
 class DummyClass extends Request
 {

--- a/src/Helpers/module.php
+++ b/src/Helpers/module.php
@@ -10,24 +10,32 @@ if (! function_exists('module_path')) {
      */
     function module_path($module = null, $file = '')
     {
+        $modulesPath = config('modules.path');
+        $pathMap = config('modules.pathMap');
+
+        if (!empty($file) && !empty($pathMap)) {
+            $file = str_replace(
+                array_keys($pathMap),
+                array_values($pathMap),
+                $file
+            );
+        }
+
+        $filePath = $file ? '/' . ltrim($file, '/') : '';
+
         if (is_null($module)) {
             if (empty($file)) {
-                return config('modules.path');
+                return $modulesPath;
             }
 
-            return config('modules.path').'/'.$file;
+            return $modulesPath . $filePath;
         }
 
         $module = Module::where('slug', $module);
 
-        if (empty($file)) {
-            return config('modules.path').'/'.$module['basename'];
-        }
-
-        return config('modules.path').'/'.$module['basename'].'/'.$file;
+        return $modulesPath . '/' . $module['basename'] . $filePath;
     }
 }
-
 
 if (! function_exists('module_class')) {
     /**


### PR DESCRIPTION
This PR adds a new configuration option that allows modifying the default paths of components within a module. By default, the normal directory structure is used as it was already working. The main changes are:

* Update `module_path` to apply the mapping configurations to the given paths.
* Ensure that `module_path` is used in generators and migration commands.
* Apply the same mapping configuration when generating new modules (which doesn't use `module_path` per generated file). 

It also fixes a missing slash in some of the stubs' `use` statements. 

This applies to feature request #121.