### PR TITLE
Fix module:migrate:rollback for modules

### DIFF
--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Caffeinated\Modules\Providers;
 
+use Caffeinated\Modules\Database\Migrations\Migrator;
 use Illuminate\Support\ServiceProvider;
 
 class ConsoleServiceProvider extends ServiceProvider
@@ -108,7 +109,11 @@ class ConsoleServiceProvider extends ServiceProvider
     protected function registerMigrateRollbackCommand()
     {
         $this->app->singleton('command.module.migrate.rollback', function ($app) {
-            return new \Caffeinated\Modules\Console\Commands\ModuleMigrateRollbackCommand($app['modules']);
+            $repository = $app['migration.repository'];
+            $table = $app['config']['database.migrations'];
+
+            $migrator = new Migrator($table, $repository, $app['db'], $app['files']);
+            return new \Caffeinated\Modules\Console\Commands\ModuleMigrateRollbackCommand($migrator, $app['modules']);
         });
 
         $this->commands('command.module.migrate.rollback');


### PR DESCRIPTION
- Rolls back a batch which was created through module:migrate
- Rolls back only the migrations for the provided slug, even if multiple migrations were executed in the same batch

Not sure about the getRanMigrations method in the Migrator, but couldn't find any clever way to 'rewrite' the DatabaseMigrationRepository.

My migrations:

```
id	migration				batch
1	2016_11_07_193451_create_test1_table	1
2	2016_11_07_193513_non_module_migration	2
3	2016_11_07_193542_create_test2_table	3
4	2016_11_07_193559_non_module_migration	4
5	2016_11_07_193617_update_test1_table	5
6	2016_11_07_193700_update_test2_table	6
```

This is how the rollbacks would look like:
```
$ php artisan module:migrate:rollback --pretend
UpdateTest2Table: alter table `test2` drop `test2_column`

$ php artisan module:migrate:rollback --pretend --step 3
UpdateTest2Table: alter table `test2` drop `test2_column`
UpdateTest1Table: alter table `test1` drop `test1_column`
CreateTest2Table: drop table `test2`
CreateTest1Table: drop table `test1`

$ php artisan module:migrate:rollback test1 --pretend --step 2
UpdateTest1Table: alter table `test1` drop `test1_column`
CreateTest1Table: drop table `test1`
```