### PR TITLE
Request validator must extend FormRequest

### DIFF
--- a/src/Console/Generators/stubs/request.stub
+++ b/src/Console/Generators/stubs/request.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespace\Http\Requests\Request;
+use Illuminate\Foundation\Http\FormRequest;
 
-class DummyClass extends Request
+class DummyClass extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
File generated from "php artisan make:module:request" must extend the FormRequest class of Laravel Illuminate.

Here is the TestRequest class generated using "php artisan make:request" command.

    <?php

    namespace App\Http\Requests;

    use Illuminate\Foundation\Http\FormRequest;

    class TestRequest extends FormRequest
    {
        /**
         * Determine if the user is authorized to make this request.
         *
         * @return bool
         */
        public function authorize()
        {
            return false;
        }

        /**
         * Get the validation rules that apply to the request.
         *
         * @return array
         */
        public function rules()
        {
            return [
                //
            ];
        }
    }
