### PR TITLE
Fixed incorrect reference in Seed Command

### DIFF
--- a/src/Console/Commands/ModuleSeedCommand.php
+++ b/src/Console/Commands/ModuleSeedCommand.php
@@ -86,8 +86,8 @@ class ModuleSeedCommand extends Command
         $module = $this->module->where('slug', $slug);
         $params = [];
         $namespacePath = $this->module->getNamespace();
-        $rootSeeder = $module['name'].'DatabaseSeeder';
-        $fullPath = $namespacePath.'\\'.$module['name'].'\Database\Seeds\\'.$rootSeeder;
+        $rootSeeder = $module['basename'].'DatabaseSeeder';
+        $fullPath = $namespacePath.'\\'.$module['basename'].'\Database\Seeds\\'.$rootSeeder;
 
         if (class_exists($fullPath)) {
             if ($this->option('class')) {


### PR DESCRIPTION
The seed command attempted to make the fullPath using the "name" attribute.  Resolved by using "basename" instead.

Example:
```
Module name: "Airfield Information Services"
Module basename; "Ais"
Module slug: "ais"

FullPath: \App\Modules\Airfield Information Services\Database\Seeds\Airfield Information ServicesDatabaseSeeder.php
New FullPath: \App\Modules\Ais\Database\Seeds\AisDatabaseSeeder.php
```

Fixes #245 and fixes #227