### PR TITLE
Slugs-collection, strtolower every module-item

### DIFF
--- a/src/Repositories/LocalRepository.php
+++ b/src/Repositories/LocalRepository.php
@@ -24,7 +24,7 @@ class LocalRepository extends Repository
         $slugs = collect();
 
         $this->all()->each(function ($item, $key) use ($slugs) {
-            $slugs->push($item['slug']);
+            $slugs->push(strtolower($item['slug']));
         });
 
         return $slugs;


### PR DESCRIPTION
This 'fix' will solve problems in the `exists($slug)` function where the `$slug` will be str_slug-based-checked if it exists in the collection.

In the old situation a slug/module like `FooBar` had to match with `foobar`, but that fails. In the new situation we strtolower the slug/modules, so `foobar` matched with `foobar`.