### PR TITLE
make "yes" by default in confirmation of make:module

### DIFF
--- a/src/Console/Generators/MakeModuleCommand.php
+++ b/src/Console/Generators/MakeModuleCommand.php
@@ -107,7 +107,7 @@ class MakeModuleCommand extends Command
         $this->comment('Basename (auto-generated):  '.$this->container['basename']);
         $this->comment('Namespace (auto-generated): '.$this->container['namespace']);
 
-        if ($this->confirm('If the provided information is correct, type "yes" to generate.')) {
+        if ($this->confirm('If the provided information is correct, type "yes" to generate.', true)) {
             $this->comment('Thanks! That\'s all we need.');
             $this->comment('Now relax while your module is generated.');
 


### PR DESCRIPTION
When you make new module with "make:module ModuleName" command, final question looks like this

`If the provided information is correct, type "yes" to generate. (yes/no) [no]:`

By default it uses `no`, but it will be more handy if it uses `yes` by default. That is what I've done.