### PR TITLE
private to protected on stepOne() in MakeModuleCommand

### DIFF
--- a/src/Console/Generators/MakeModuleCommand.php
+++ b/src/Console/Generators/MakeModuleCommand.php
@@ -88,7 +88,7 @@ class MakeModuleCommand extends Command
      *
      * @return mixed
      */
-    private function stepOne()
+    protected function stepOne()
     {
         $this->displayHeader('make_module_step_1');
 


### PR DESCRIPTION
Should keep classes flexible for extending. In this case IMO it makes sense to have this method be **protected** instead of **private**.