### PR TITLE
 Add the ModuleNotFoundException.

### DIFF
--- a/src/Exceptions/ModuleNotFoundException.php
+++ b/src/Exceptions/ModuleNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Created by Pankit Gami
+ * Date: 11/4/17
+ * Time: 5:27 PM
+ */
+
+namespace Caffeinated\Modules\Exceptions;
+
+
+class ModuleNotFoundException extends \Exception {
+
+	/**
+	 * ModuleNotFoundException constructor.
+	 */
+	public function __construct( $slug ) {
+		parent::__construct('Module with slug name [' . $slug . '] not found');
+	}
+}

--- a/src/Helpers/module.php
+++ b/src/Helpers/module.php
@@ -1,14 +1,18 @@
 <?php
 
+use Caffeinated\Modules\Exceptions\ModuleNotFoundException;
+
 if (! function_exists('module_path')) {
-    /**
-     * Return the path to the given module file.
-     *
-     * @param  string  $module
-     * @param  string  $file
-     * @return string
-     */
-    function module_path($module = null, $file = '')
+	/**
+	 * Return the path to the given module file.
+	 *
+	 * @param  string $slug
+	 * @param  string $file
+	 *
+	 * @return string
+	 * @throws \Caffeinated\Modules\Exceptions\ModuleNotFoundException
+	 */
+    function module_path($slug = null, $file = '')
     {
         $modulesPath = config('modules.path');
         $pathMap = config('modules.pathMap');
@@ -23,7 +27,7 @@ if (! function_exists('module_path')) {
 
         $filePath = $file ? '/' . ltrim($file, '/') : '';
 
-        if (is_null($module)) {
+        if (is_null($slug)) {
             if (empty($file)) {
                 return $modulesPath;
             }
@@ -31,23 +35,34 @@ if (! function_exists('module_path')) {
             return $modulesPath . $filePath;
         }
 
-        $module = Module::where('slug', $module);
+        $module = Module::where('slug', $slug);
+
+        if (is_null($module)){
+			throw new ModuleNotFoundException($slug);
+        }
 
         return $modulesPath . '/' . $module['basename'] . $filePath;
     }
 }
 
 if (! function_exists('module_class')) {
-    /**
-     * Return the full path to the given module class.
-     *
-     * @param  string  $module
-     * @param  string  $class
-     * @return string
-     */
-    function module_class($module, $class)
+	/**
+	 * Return the full path to the given module class.
+	 *
+	 * @param  string $slug
+	 * @param  string $class
+	 *
+	 * @return string
+	 * @throws \Caffeinated\Modules\Exceptions\ModuleNotFoundException
+	 */
+    function module_class($slug, $class)
     {
-        $module    = Module::where('slug', $module);
+	    $module = Module::where('slug', $slug);
+
+	    if ( is_null($module) ) {
+		    throw new ModuleNotFoundException($slug);
+	    }
+
         $namespace = config('modules.namespace').$module['basename'];
 
         return "{$namespace}\\{$class}";


### PR DESCRIPTION
PR for issue #289 .

Rename the `$module` in `module_class` and `module_path` to `$slug` as when a user passes the slug we don't know whether it is an actual module or just any string. So it would be better to name it as the slug.