### PR TITLE
Avoiding error exception in console command

### DIFF
--- a/src/Console/Commands/ModuleListCommand.php
+++ b/src/Console/Commands/ModuleListCommand.php
@@ -89,9 +89,9 @@ class ModuleListCommand extends Command
     {
         return [
             '#'           => $module['order'],
-            'name'        => $module['name'],
+            'name'        => isset($module['name']) ? $module['name'] : '',
             'slug'        => $module['slug'],
-            'description' => $module['description'],
+            'description' => isset($module['description']) ? $module['description'] : '',
             'status'      => ($this->module->isEnabled($module['slug'])) ? 'Enabled' : 'Disabled',
         ];
     }


### PR DESCRIPTION
This avoids an error when running the `module:list` command on the console:

> [ErrorException]
> Undefined index: name

