### PR TITLE
Allow module configuration files

### DIFF
--- a/resources/stubs/module/Providers/ModuleServiceProvider.php
+++ b/resources/stubs/module/Providers/ModuleServiceProvider.php
@@ -16,6 +16,7 @@ class ModuleServiceProvider extends ServiceProvider
         $this->loadTranslationsFrom(__DIR__.'/../Resources/Lang', 'DummySlug');
         $this->loadViewsFrom(__DIR__.'/../Resources/Views', 'DummySlug');
         $this->loadMigrationsFrom(__DIR__.'/../Database/Migrations', 'DummySlug');
+        $this->loadConfigsFrom(__DIR__.'/../config');
     }
 
     /**

--- a/src/Support/ServiceProvider.php
+++ b/src/Support/ServiceProvider.php
@@ -35,4 +35,20 @@ class ServiceProvider extends IlluminateServiceProvider
             $kernel->pushMiddleware($middleware);
         }
     }
+
+    /**
+     * Register any additional config.
+     *
+     * @param string $path
+     *
+     * @return void
+     */
+    protected function loadConfigsFrom($path)
+    {
+        foreach (glob($path.'/*.php') as $file) {
+            $fileName = str_replace($path.'/', '', $file);
+            $key = substr($fileName, 0, -4);
+            $this->app['config']->set($key, array_merge_recursive(config($key, []), require $file));
+        }
+    }
 }


### PR DESCRIPTION
It brings the same behavior as the native config. 
It will loads **every config** files inside the module **config folder** and will be accessible through anywhere from the config helper.