### PR TITLE
Remove str_slug since Module slug can be created without being slugged

### DIFF
--- a/src/Repositories/LocalRepository.php
+++ b/src/Repositories/LocalRepository.php
@@ -80,7 +80,7 @@ class LocalRepository extends Repository
      */
     public function exists($slug)
     {
-        return $this->slugs()->contains(str_slug($slug));
+        return $this->slugs()->contains($slug);
     }
 
     /**


### PR DESCRIPTION
We can create modules with slugs containing underscores but the **Module::exists($slug)** method convert the slug through **str_slug** and will convert those characters into dashes.

This is an issue since it si not possible to test if the module exists in this case.
