### PR TITLE
Fixed the 'Modules->Exists'-check to detect older Modules-version correctly ...

### DIFF
--- a/src/Repositories/LocalRepository.php
+++ b/src/Repositories/LocalRepository.php
@@ -80,7 +80,7 @@ class LocalRepository extends Repository
      */
     public function exists($slug)
     {
-        return $this->slugs()->contains($slug);
+        return ($this->slugs()->contains($slug) || $this->slugs()->contains(str_slug($slug)));
     }
 
     /**


### PR DESCRIPTION
Noticed - during a upgrade to Laravel 5.6 - there was a change made in the 'exists'-function, I modified the function a little bit, b/c it could break Modules made in older versions of this plugin ... 