### PR TITLE
Add config option to set module service provider

### DIFF
--- a/config/modules.php
+++ b/config/modules.php
@@ -43,6 +43,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Modules Default Service Provider class name
+    |--------------------------------------------------------------------------
+    |
+    | Define class name to use as default module service provider.
+    |
+    */
+
+    'provider_class' => 'Providers\\ModuleServiceProvider',
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Module Driver
     |--------------------------------------------------------------------------
     |

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -59,7 +59,7 @@ class Modules
      */
     private function registerServiceProvider($module)
     {
-        $serviceProvider = module_class($module['slug'], 'Providers\\ModuleServiceProvider');
+        $serviceProvider = module_class($module['slug'], config('modules.provider_class', 'Providers\\ModuleServiceProvider'));
 
         if (class_exists($serviceProvider)) {
             $this->app->register($serviceProvider);


### PR DESCRIPTION
Sometimes we need to change location of default module service provider.
For example, when making module structure in ddd like style.
```
App/ServiceProviders
Domain/Model
Ui/Http/Controller
```
So, it would be great to change provider location from module config.