### PR TITLE
Fix/restore the factories check in ModuleSeedCommand #370 ..

### DIFF
--- a/src/Console/Commands/ModuleSeedCommand.php
+++ b/src/Console/Commands/ModuleSeedCommand.php
@@ -88,7 +88,6 @@ class ModuleSeedCommand extends Command
         $namespacePath = $this->module->getNamespace();
         $rootSeeder = $module['basename'].'DatabaseSeeder';
         $fullPath = $namespacePath.'\\'.$module['basename'].'\Database\Seeds\\'.$rootSeeder;
-        $factoriesPath = module_path($slug).DIRECTORY_SEPARATOR.'Database'.DIRECTORY_SEPARATOR.'Factories'.DIRECTORY_SEPARATOR;
 
         if (class_exists($fullPath)) {
             if ($this->option('class')) {
@@ -105,9 +104,7 @@ class ModuleSeedCommand extends Command
                 $params['--force'] = $option;
             }
 
-            if (count(glob($factoriesPath.'*.php')) > 0) {
-                $this->call('db:seed', $params);
-            }
+            $this->call('db:seed', $params);
 
             event($slug.'.module.seeded', [$module, $this->option()]);
         }


### PR DESCRIPTION
When you don't use factories in a module (only 'simple' flat-files), the module-seed command won't run anymore (since it checks for the factories files count), this pr fixed it to the original behaviour ...