### PR TITLE
Fix'd the ModuleSeedCommand location/repository-option ..

### DIFF
--- a/src/Console/Commands/ModuleSeedCommand.php
+++ b/src/Console/Commands/ModuleSeedCommand.php
@@ -48,7 +48,7 @@ class ModuleSeedCommand extends Command
      */
     public function handle()
     {
-        $repository = modules($this->option('location'));
+        $repository = modules($this->option('location') ?? config('modules.default_location'));
 
         $slug = $this->argument('slug');
 


### PR DESCRIPTION
After upgrading to v5.0, republishing the config-files and running `php artisan module:seed`, the following error comes

```
In ModuleSeedCommand.php line 91:
                                                                                                                                                  
  Argument 2 passed to Caffeinated\Modules\Console\Commands\ModuleSeedCommand::seed() must be an instance of Caffeinated\Modules\Repositories\Re  
  pository, instance of Caffeinated\Modules\RepositoryManager given, called in [..]/vendor/caffeinated/modules/src/Cons  
  ole/Commands/ModuleSeedCommand.php on line 78
```

This pr checks if the `location-option` is set, otherwise using the `default_location` from the config-file instead