### PR TITLE
Fix config if cached

### DIFF
--- a/resources/stubs/module/Providers/ModuleServiceProvider.php
+++ b/resources/stubs/module/Providers/ModuleServiceProvider.php
@@ -16,7 +16,9 @@ class DummyProvider extends ServiceProvider
         $this->loadTranslationsFrom(module_path('DummySlug', 'ResourcesLangMapping', 'DummyLocation'), 'DummySlug');
         $this->loadViewsFrom(module_path('DummySlug', 'ResourcesViewsMapping', 'DummyLocation'), 'DummySlug');
         $this->loadMigrationsFrom(module_path('DummySlug', 'DatabaseMigrationsMapping', 'DummyLocation'), 'DummySlug');
-        $this->loadConfigsFrom(module_path('DummySlug', 'ConfigMapping', 'DummyLocation'));
+        if(!$this->app->configurationIsCached()) {
+            $this->loadConfigsFrom(module_path('DummySlug', 'ConfigMapping', 'DummyLocation'));
+        }
         $this->loadFactoriesFrom(module_path('DummySlug', 'DatabaseFactoriesMapping', 'DummyLocation'));
     }
 


### PR DESCRIPTION
When settings are cached, it generates duplicity.
And the values are returned duplicates in an array.