### PR TITLE
Removed unrequired 2nd parameter to loadMigrationsFrom()

### DIFF
--- a/resources/stubs/module/Providers/ModuleServiceProvider.php
+++ b/resources/stubs/module/Providers/ModuleServiceProvider.php
@@ -15,7 +15,7 @@ class DummyProvider extends ServiceProvider
     {
         $this->loadTranslationsFrom(module_path('DummySlug', 'ResourcesLangMapping', 'DummyLocation'), 'DummySlug');
         $this->loadViewsFrom(module_path('DummySlug', 'ResourcesViewsMapping', 'DummyLocation'), 'DummySlug');
-        $this->loadMigrationsFrom(module_path('DummySlug', 'DatabaseMigrationsMapping', 'DummyLocation'), 'DummySlug');
+        $this->loadMigrationsFrom(module_path('DummySlug', 'DatabaseMigrationsMapping', 'DummyLocation'));
         if(!$this->app->configurationIsCached()) {
             $this->loadConfigsFrom(module_path('DummySlug', 'ConfigMapping', 'DummyLocation'));
         }


### PR DESCRIPTION
Removed DummySlug passed as second parameter to loadMigrationsFrom method in ModuleServiceProvider stub file.

This was causing the following warning:
_Method Illuminate\Support\ServiceProvider::loadMigrationsFrom() invoked with 2 parameters, 1 required._