### PR TITLE
Update `module_path` doc block to indicate $location can be string or…

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -25,7 +25,7 @@ if (!function_exists('module_path')) {
      * @param string $slug
      * @param string $file
      *
-     * @param null $location
+     * @param string|null $location
      * @return string
      * @throws \Caffeinated\Modules\Exceptions\ModuleNotFoundException
      */


### PR DESCRIPTION
… null

Add string to the @param $location doc block to prevent the following static code analysis warning:
_Parameter #3 $location of function module_path expects null, string given._