### PR TITLE
Auto-magically load routes

### DIFF
--- a/src/Support/ServiceProvider.php
+++ b/src/Support/ServiceProvider.php
@@ -81,16 +81,6 @@ class ServiceProvider extends IlluminateServiceProvider
             if (Module::exists($slug) && Module::isEnabled($slug)) {
                 $module = Module::where('slug', $slug);
 
-                if (file_exists(module_path($slug, 'routes/datatable.php'))) {
-                    Route::group([
-                        'middleware' => 'api',
-                        'namespace'  => "Modules\\{$module->get('basename')}\\Http\\Controllers\\DataTable",
-                        'prefix'     => 'datatable',
-                    ], function ($router) use ($slug) {
-                        require module_path($slug, 'routes/datatable.php');
-                    });
-                }
-
                 if (file_exists(module_path($slug, 'routes/web.php'))) {
                     Route::group([
                         'middleware' => 'web',

--- a/src/Support/ServiceProvider.php
+++ b/src/Support/ServiceProvider.php
@@ -70,6 +70,50 @@ class ServiceProvider extends IlluminateServiceProvider
     }
 
     /**
+     * Load the given module routes files if not already cached.
+     *
+     * @param  string  $string
+     * @return void
+     */
+    protected function loadRoutesFor($slug)
+    {
+        if (! ($this->app instanceof CachesRoutes && $this->app->routesAreCached())) {
+            if (Module::exists($slug) && Module::isEnabled($slug)) {
+                $module = Module::where('slug', $slug);
+
+                if (file_exists(module_path($slug, 'routes/datatable.php'))) {
+                    Route::group([
+                        'middleware' => 'api',
+                        'namespace'  => "Modules\\{$module->get('basename')}\\Http\\Controllers\\DataTable",
+                        'prefix'     => 'datatable',
+                    ], function ($router) use ($slug) {
+                        require module_path($slug, 'routes/datatable.php');
+                    });
+                }
+
+                if (file_exists(module_path($slug, 'routes/web.php'))) {
+                    Route::group([
+                        'middleware' => 'web',
+                        'namespace'  => "Modules\\{$module->get('basename')}\\Http\\Controllers\\Web",
+                    ], function ($router) use ($slug) {
+                        require module_path($slug, 'routes/web.php');
+                    });
+                }
+
+                if (file_exists(module_path($slug, 'routes/api.php'))) {
+                    Route::group([
+                        'middleware' => 'api',
+                        'namespace'  => "Modules\\{$module->get('basename')}\\Http\\Controllers\\API",
+                        'prefix'     => 'api',
+                    ], function ($router) use ($slug) {
+                        require module_path($slug, 'routes/api.php');
+                    });
+                }
+            }
+        }
+    }
+
+    /**
      * Get all of the configuration files for the application.
      *
      * @param  string  $path


### PR DESCRIPTION
This update introduces a new support method `loadRoutesFor($slug)` to be used in `Caffeinated\Modules\Support\ServiceProvider` in order to eliminate the need to load `RoutesServiceProvider` (other than for personal customization).

## Usage
```
<?php

    namespace Modules\Acme\Providers;

    use Caffeinated\Modules\Support\ServiceProvider;

    class ModuleServiceProvider extends ServiceProvider
    {
        public function boot()
        {
            $this->loadRoutesFor('acme');

            ...
        }

        ...
    }
```

The method takes the module's `slug` as an argument, in order to auto-magically include the following route files:

```
Acme/
  | src
    | routes/
      | api.php
      | web.php
```

## Additional Comments
Named `loadRoutesFor` as to not be confused with Laravel's `loadRoutesFrom`, which takes a `$path` as an argument.