### PR TITLE
Missing s in config key for registering custom service provider

### DIFF
--- a/src/RepositoryManager.php
+++ b/src/RepositoryManager.php
@@ -67,7 +67,7 @@ class RepositoryManager
     private function registerServiceProvider(Repository $repository, $module)
     {
         $location        = $repository->location;
-        $provider        = config("modules.location.$location.provider", 'Providers\\ModuleServiceProvider');
+        $provider        = config("modules.locations.$location.provider", 'Providers\\ModuleServiceProvider');
         $serviceProvider = module_class($module['slug'], $provider, $location);
 
         if (class_exists($serviceProvider)) {


### PR DESCRIPTION
Hey there, I've just tried to use a custom service provider for an additional module location and realised there was a missing s in the config key for that custom provider.

I started putting together a test for it but was unsure of the best location for the test.